### PR TITLE
[build] Respect value of $(CC) variable

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,8 @@ SYMBOL_PREFIX	:=
 #
 # Locations of tools
 #
-HOST_CC		:= gcc
+CC		?= gcc
+HOST_CC		:= $(CC)
 RM		:= rm -f
 TOUCH		:= touch
 MKDIR		:= mkdir
@@ -26,7 +27,7 @@ PRINTF		:= printf
 PERL		:= perl
 PYTHON		:= python
 TRUE		:= true
-CC		:= $(CROSS_COMPILE)gcc
+CC		:= $(CROSS_COMPILE)$(CC)
 CPP		:= $(CC) -E
 AS		:= $(CROSS_COMPILE)as
 LD		:= $(CROSS_COMPILE)ld


### PR DESCRIPTION
On FreeBSD the gcc package installs a versioned binary such as "gcc12".  There is no plain "gcc" binary.

Simplify building on such systems by respecting the $(CC) variable.

Modified-by: Michael Brown <mcb30@ipxe.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved flexibility in compiler settings by introducing default values for compiler variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->